### PR TITLE
Microbit Bluetooth ioPinService expects little-endian byte order

### DIFF
--- a/src/services/io-pin.ts
+++ b/src/services/io-pin.ts
@@ -65,7 +65,7 @@ export interface PwmControlData {
      */
     value: number;
     /**
-     * Period (in milliseconds)
+     * Period (in microseconds)
      */
     period: number;
 }

--- a/src/services/io-pin.ts
+++ b/src/services/io-pin.ts
@@ -36,6 +36,8 @@ export enum IoPinCharacteristic {
     pwmControl = "e95dd822-251d-470a-a062-fa1922dfa9a8"
 }
 
+const littleEndian = true;
+
 /**
  * Pin data
  */
@@ -244,7 +246,7 @@ export class IoPinService extends (EventDispatcher as new() => TypedDispatcher<I
             value &= 1 << config[i];
         }
 
-        view.setUint16(0, value >> 8);
+        view.setUint16(0, value >> 8, littleEndian);
         view.setUint8(2, value & 0xff);
         return view;
     }
@@ -252,8 +254,8 @@ export class IoPinService extends (EventDispatcher as new() => TypedDispatcher<I
     private pwmControlDataToDataView(data: PwmControlData): DataView {
         const view = new DataView(new ArrayBuffer(7));
         view.setUint8(0, data.pin);
-        view.setUint16(1, data.value);
-        view.setUint32(3, data.period);
+        view.setUint16(1, data.value, littleEndian);
+        view.setUint32(3, data.period, littleEndian);
         return view;
     }
 }


### PR DESCRIPTION
Hi, thanks for all your work on this great project!

I was trying to use the Bluetooth ioPinService to control some servos from my micro:bit, and getting strange results.  I think that the Microbit Bluetooth API expects multi-byte data fields to be sent in little-endian order (least significant bytes first.) 

https://lancaster-university.github.io/microbit-docs/resources/bluetooth/bluetooth_profile.html

Also, those docs expect the PWM period to be set in microseconds, not milliseconds like in the comment.

With these changes I'm able to get the results I expected from my servos. Thanks again!
